### PR TITLE
Blog comment submission

### DIFF
--- a/_data/comments/on-complete-ordered-fields/comment-1568399977792.yml
+++ b/_data/comments/on-complete-ordered-fields/comment-1568399977792.yml
@@ -1,0 +1,6 @@
+_id: d6b59760-d655-11e9-b777-a1f56fd4ee18
+name: Andrej
+email: 59d57d95bc7c45ced5f1969279cec06b
+url: 'http://www.andrej.com/'
+message: "As far as I can tell, Toby's argument requires cotransitivity of $<$, above I explicitly noted  this in the proof which gets you excluded middle from a complete order: the supremum $s$ of the set $S$ is either above $a$ or below $b$.\r\n\r\nThe idea to have $\\lnot\\lnot$-bounded Dedekind cuts is good! Let's see, in $Sh(X)$ for a reasonable $X$ the Dedekind cuts are the sheaf of real-valued continuous maps. The unbounded cuts correspond to maps into $[-\\infty,\\infty]$. The $\\lnot\\lnot$-bounded ones would be the maps into $[-\\infty, \\infty]$ which take on values $-\\infty$ and $\\infty$ on a set with empty interior? Indeed, those will fail to be locally bounded (which is what the archimedean axiom amounts to)."
+date: 1568399977


### PR DESCRIPTION
Merge the pull request to accept it, or close it to send it away.

| Field   | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| name    | Andrej                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| email   | 59d57d95bc7c45ced5f1969279cec06b                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
| url     | http://www.andrej.com/                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| message | As far as I can tell, Toby's argument requires cotransitivity of $<$, above I explicitly noted  this in the proof which gets you excluded middle from a complete order: the supremum $s$ of the set $S$ is either above $a$ or below $b$.

The idea to have $\lnot\lnot$-bounded Dedekind cuts is good! Let's see, in $Sh(X)$ for a reasonable $X$ the Dedekind cuts are the sheaf of real-valued continuous maps. The unbounded cuts correspond to maps into $[-\infty,\infty]$. The $\lnot\lnot$-bounded ones would be the maps into $[-\infty, \infty]$ which take on values $-\infty$ and $\infty$ on a set with empty interior? Indeed, those will fail to be locally bounded (which is what the archimedean axiom amounts to). |
| date    | 1568399977                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |