### PR TITLE
Fix feed.xml by setting a base URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
 name: Mathematics and Computation
 description: A blog about mathematics for computers
+url: http://math.andrej.com
 
 kramdown:
   hard_wrap: false


### PR DESCRIPTION
Fixes the errors in https://validator.w3.org/feed/check.cgi?url=http%3A%2F%2Fmath.andrej.com%2Ffeed.xml (tested locally)